### PR TITLE
function autoclose#enable_autoclose_tagのエラーを解消

### DIFF
--- a/autoload/autoclose.vim
+++ b/autoload/autoclose.vim
@@ -105,7 +105,7 @@ endfunction
 "
 function! autoclose#enable_autoclose_tag() abort
   let filetypes = join(s:enabled_autoclosing_tags_filetypes, ',')
-  execute "augroup autocloseTag | au! | au FileType " .. filetypes .. " call s:mapping_autoclose_tags() | augroup EMD"
+  execute "augroup autocloseTag | au! | au FileType " . filetypes . " call s:mapping_autoclose_tags() | augroup EMD"
 endfunction
 
 "


### PR DESCRIPTION
~/.vim/pack/plugins/start/ にシンボリックリンクを貼り、VSCodeのターミナルでvimを起動したところ以下のエラーが発生しました。

#########################################################################################
Error detected while processing function autoclose#enable_autoclose_tag:
line    2:
E15: Invalid expression: . filetypes .. " call s:mapping_autoclose_tags() | augroup EMD"
E15: Invalid expression: "augroup autocloseTag | au! | au FileType " .. filetypes .. " call s:mapping_autoclose_tags() | augroup EMD"
Press ENTER or type command to continue
#########################################################################################

. を省いたところエラーが解消されました。

なお、プラグインは""や()などの動作確認はできましたが、タグ<>の補完だけが機能していない状況です。（私の使い方が間違っていたら申し訳ありません)
よろしくお願いいたします。